### PR TITLE
feat/healthPopup

### DIFF
--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -299,6 +299,35 @@ public final class DrawManager {
         drawCenteredRegularString(screen, text, y + popupHeight / 2 + 5);
     }
 
+    /**
+     * Draws a notification popup for changes in health
+     *
+     * @param screen
+     *          Screen to draw on.
+     * @param text
+     *          Text to display change in health (+1 Health / -1 Health).
+     */
+    public void drawHealthPopup(final Screen screen, final String text) {
+        int popupWidth = 250;
+        int popupHeight = 40;
+        int x = screen.getWidth() / 2 - popupWidth / 2;
+        int y = 100;
+
+        backBufferGraphics.setColor(new Color(0, 0, 0, 200));
+        backBufferGraphics.fillRoundRect(x, y, popupWidth, popupHeight, 15, 15);
+
+        Color textColor;
+        if (text.startsWith("+")) {
+            textColor = new Color(50, 255, 50);
+        } else {
+            textColor = new Color(255, 50, 50);
+        }
+
+        backBufferGraphics.setColor(textColor);
+        drawCenteredBigString(screen, text, y + popupHeight / 2 + 5);
+    }
+
+
 	/**
 	 * Draws a thick line from side to side of the screen.
 	 * 

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -75,6 +75,9 @@ public class GameScreen extends Screen {
     // Achievement popup
     private String achievementText;
     private Cooldown achievementPopupCooldown;
+    /** Health change popup. */
+    private String healthPopupText;
+    private Cooldown healthPopupCooldown;
 
 	/**
 	 * Constructor, establishes the properties of the screen.
@@ -247,6 +250,13 @@ public class GameScreen extends Screen {
         }
 
 
+        // Health notification popup
+        if(this.healthPopupText != null && !this.healthPopupCooldown.checkFinished()) {
+            drawManager.drawHealthPopup(this, this.healthPopupText);
+        } else {
+            this.healthPopupText = null;
+        }
+
         // Countdown to game start.
 		if (!this.inputDelay.checkFinished()) {
 			int countdown = (int) ((INPUT_DELAY
@@ -290,6 +300,7 @@ public class GameScreen extends Screen {
 					if (!this.ship.isDestroyed()) {
 						this.ship.destroy();
 						this.lives--;
+                        showHealthPopup("-1 Health");
 						this.logger.info("Hit on player ship, " + this.lives
 								+ " lives remaining.");
 					}
@@ -343,6 +354,7 @@ public class GameScreen extends Screen {
 
 		return distanceX < maxDistanceX && distanceY < maxDistanceY;
 	}
+
     /**
      * Shows an achievement popup message on the HUD.
      *
@@ -353,6 +365,19 @@ public class GameScreen extends Screen {
         this.achievementText = message;
         this.achievementPopupCooldown = Core.getCooldown(2500); // Show for 2.5 seconds
         this.achievementPopupCooldown.reset();
+    }
+
+    /**
+     * Displays a notification popup when the player gains or loses health
+     *
+     * @param message
+     *          Text to display in the popup
+     */
+
+    public void showHealthPopup(String message) {
+        this.healthPopupText = message;
+        this.healthPopupCooldown = Core.getCooldown(500);
+        this.healthPopupCooldown.reset();
     }
 
     /**


### PR DESCRIPTION
Added a HUD notification system for changes in player lives using the showHealthPopup method. The popup displays a message indicating an increase or decrease in health for 0.5 seconds and automatically disappears. Is purely visual and does not affect the actual player lives. 

As there is no health increase implemented yet, to test the green popup text, temporarily add showHealthPopup("+1 Health"); inside manageCollisions() when an enemy ship is hit.

